### PR TITLE
marked as discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ FINLAND
   
 UK
 
-  * [DSSGx UK Summer Fellowship](https://warwick.ac.uk/research/data-science/warwick-data/dssgx/), University of Warwick
+  * [DSSGx UK Summer Fellowship](https://warwick.ac.uk/research/data-science/warwick-data/dssgx/), University of Warwick (Discontinued!)
   * [Visual Geometry Group](https://www.robots.ox.ac.uk/~vgg/)
 
 INDIA


### PR DESCRIPTION
DSSGx UK no longer running
We have run DSSGx UK at the University of Warwick every year from 2019 to 2023. Every year we had amazing fellows from all over the world working with a range of project partners, from small charities to large international organisations, on a variety of projects in areas including education, poverty, health, or environment. In all these projects, we designed and implemented open-source data science solutions that help our project partners to make better use of their data, and achieve a greater social impact.
This website is a testament of the achievements over the five years from 2019 to 2023, with 5 minute video presentations of all the projects (just click on the different years on the right).
Unfortunately, we have not been able to secure sufficient external funding to continue running DSSGx UK for the time being.