### PR TITLE
docs: add Hanzilla Canada student jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The following are some worldwide research internship positions:
 #### <img src="images/flags/ca.png" alt="Canadian flag" width="15"> Canada
   * ~~[MITACS Globalink](https://www.mitacs.ca/en/programs/globalink/globalink-research-internship), for research positions in Canada.~~ (NO LONGER AVAILABLE)
   * [University of Alberta Research Experience (UARE)](https://www.ualberta.ca/admissions-programs/visiting-student-and-internship-programs/research-internships/ualberta-research-experience/index.html)
+  * [Hanzilla Jobs - Canadian science and research-adjacent student jobs](https://jobs.hanzilla.co/sciences/) - Daily-updated Canada-focused board for internships, co-ops, new grad, junior, and entry-level roles across sciences, data, engineering, business, and related fields.
 
 ## Europe
 


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs under the Canada section as a current student/new-grad jobs resource.
- Link directly to the science/research-adjacent Canadian student jobs page.

## Why this fits
Hanzilla Jobs is a free daily-updated Canadian student/recent-grad job board covering internships, co-ops, new grad, junior, and entry-level roles across sciences, data, engineering, business, and related fields. It complements the Canada research-internship entries for students looking for ongoing paid early-career opportunities.

## Test plan
- README-only change
- `git diff --check`
